### PR TITLE
chore: update repository for github packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "grafana",
     "typescript"
   ],
-  "repository": "github:grafana/tsconfig-grafana",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/grafana/tsconfig-grafana.git"
+  },
   "main": "tsconfig.json",
   "files": [
     "base.json",


### PR DESCRIPTION
This PR updates package.json so we can publish this package to github packages.  Required for https://github.com/grafana/grafana/issues/27953

Without this change when trying to publish to github npm errors out with`"failed to stream package from json: invalid repo host"`.