### PR TITLE
CI: introduce NPM publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,53 @@
+name: publish-npm
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Publish to NPM & GitHub Package Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      # limit releases to version changes - https://github.com/EndBug/version-check
+      - name: Check version changes
+        uses: EndBug/version-check@v1
+        id: version_check
+        with:
+          # diff the commits rather than commit message for version changes
+          diff-search: true
+
+      - name: Version update detected
+        if: steps.version_check.outputs.changed == 'true'
+        run: 'echo "Version change found! New version: ${{ steps.version_check.outputs.version }} (${{ steps.version_check.outputs.type }})"'
+
+      - name: Setup .npmrc file for NPM registry
+        if: steps.version_check.outputs.changed == 'true'
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish package to NPM
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Setup .npmrc file for GitHub Packages
+        if: steps.version_check.outputs.changed == 'true'
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@grafana"
+
+      - name: Publish package to Github Packages
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ or:
 
 
 ## Publishing
+
+Publishing is handled by github actions which is triggered by a merge to master that contains a change to the version property in the `package.json` file. You can either do that manually or use the command below to version bump, commit and tag.
+
 ```shell
-npm publish
+npm version [<newversion> | major | minor | patch ]
 ```
 
 Also be sure to update any official packages that depend on this with fixes and version increases.


### PR DESCRIPTION
Manually publishing to NPM and Github is an operation that requires access to NPM org, have to create auth tokens and edit `.npmrc` between publishing to the different registries. 

This PR adds a Github workflow for publishing this package automatically when a push to master occurs that contains a change to the version property in `package.json`.