### PR TITLE
Add `es2022` to lib

### DIFF
--- a/base.json
+++ b/base.json
@@ -10,7 +10,7 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "es2019"
+      "es2022"
     ],
     "module": "esnext",
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/tsconfig",
-  "version": "1.2.0-rc1",
+  "version": "1.3.0-rc1",
   "description": "Grafana's TypeScript config",
   "keywords": [
     "grafana",


### PR DESCRIPTION
Grafana uses a lot of es2022 features, e.g. `Array.prototype.at`

Occurrences in Grafana: https://github.com/search?q=repo%3Agrafana%2Fgrafana+%22at%28%22&type=code

In my setup this is currently leading to errors:
e.g.
![image](https://github.com/grafana/tsconfig-grafana/assets/8092184/bf7b0471-837b-4521-b222-f8dd32af8117)

