### PR TITLE
Chore: Update tsconfig target to es2018 + bump version

### DIFF
--- a/base.json
+++ b/base.json
@@ -22,6 +22,6 @@
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "es6"
+    "target": "es2018"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/tsconfig",
-  "version": "1.3.0-rc1",
+  "version": "2.0.0",
   "description": "Grafana's TypeScript config",
   "keywords": [
     "grafana",


### PR DESCRIPTION
- upgrades our tsconfig `target` to `es2018`
  - there's a typescript upgrade PR [here](https://github.com/grafana/grafana/pull/91678) that needs this
  - we're using named capture groups in regex, but the `target` specified here is too low to support those
- see slack context [here](https://raintank-corp.slack.com/archives/C02FLGJJEG4/p1723118290224049)
- we should wait for 11.2.0 to be built before merging this 👍 