### PR TITLE
CI: update gh workflow actions to latest versions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
       # limit releases to version changes - https://github.com/EndBug/version-check
       - name: Check version changes
-        uses: EndBug/version-check@v1
+        uses: EndBug/version-check@v2
         id: version_check
         with:
           # diff the commits rather than commit message for version changes
@@ -27,9 +27,9 @@ jobs:
 
       - name: Setup .npmrc file for NPM registry
         if: steps.version_check.outputs.changed == 'true'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish package to NPM
@@ -40,9 +40,9 @@ jobs:
 
       - name: Setup .npmrc file for GitHub Packages
         if: steps.version_check.outputs.changed == 'true'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "20"
           registry-url: "https://npm.pkg.github.com"
           scope: "@grafana"
 


### PR DESCRIPTION
The release workflow is throwing loads of warnings about outdated actions and node versions:

```
The following actions uses node12 which is deprecated and will be forced to run on node16
```

This PR should bring us up to date and prevent any future issues.