### PR TITLE
Bump target to ES2020, and lib to ES2023

### DIFF
--- a/base.json
+++ b/base.json
@@ -7,11 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "jsx": "react",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "es2022"
-    ],
+    "lib": ["dom", "dom.iterable", "es2023"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitHelpers": true,
@@ -22,6 +18,6 @@
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "es2018"
+    "target": "es2020"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/tsconfig",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Grafana's TypeScript config",
   "keywords": [
     "grafana",


### PR DESCRIPTION
Bumps the lib value to ES2023. This will add types for:
 - `Intl.NumberFormat`
 - `Array.prototype.findLast`
 - `Array.prototype.findLastIndex`
 - `Array.prototype.toReversed`
 - `Array.prototype.toSorted`
 - `Array.prototype.toSpliced`
 - `Array.prototype.with`
 - WeakMap symbol keys

Additionally, I've bumped the target to ES2020. This means the following features will no longer be transpiled:
 - optional catch binding `try {...} catch {...}`
 - BigInt
 - Nullish coalescing operator `??`
 - Optional chaining `?.`

I didn't go any higher than ES2020 at the moment because top-level await is specified in ES2022, which I think comes with perhaps more of a change than I would like to test for now.