### PR TITLE
Docs: add archive notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > Grafana's [TypeScript](https://typescriptlang.org) config.
 
 >[!Important]
-This repo has been archived. The Grafana tsconfig package now lives at https://github.com/grafana/plugin-tools
+This repo has been archived. The Grafana tsconfig package now lives at https://github.com/grafana/plugin-tools/packages/tsconfg
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # grafana-tsconfig
 > Grafana's [TypeScript](https://typescriptlang.org) config.
 
+>[!Important]
+This repo has been archived. The Grafana tsconfig package now lives at https://github.com/grafana/plugin-tools
+
 
 ## Installation
 ```shell


### PR DESCRIPTION
The Grafana application no longer uses this package so given the number of plugins that rely on it, it seems logical that  ownership now falls on plugins platform. We've decided it makes sense to [move it into plugin-tools](https://github.com/grafana/plugin-tools/pull/2013) and archive this repo.